### PR TITLE
Survey must gather pdx.edu email

### DIFF
--- a/grader/src/main/java/edu/pdx/cs/joy/grader/Survey.java
+++ b/grader/src/main/java/edu/pdx/cs/joy/grader/Survey.java
@@ -40,6 +40,11 @@ public class Survey extends EmailSender {
     this.gitCheckoutDir = gitCheckoutDir;
   }
 
+  public static boolean hasPdxDotEduEmail(Student student) {
+    String email = student.getEmail();
+    return email != null && email.endsWith("@pdx.edu");
+  }
+
   /**
    * Returns a textual summary of a <code>Student</code>
    */
@@ -148,7 +153,11 @@ public class Survey extends EmailSender {
     setValueIfNotEmpty(lastName, student::setLastName);
     setValueIfNotEmpty(nickName, student::setNickName);
 
-    askQuestionAndSetValue("What is your email address (doesn't have to be PSU)?", student::setEmail);
+    askQuestionAndSetValue("What is your email address (must be @pdx.edu)?", student::setEmail);
+    if (!hasPdxDotEduEmail(student)) {
+      printErrorMessageAndExit("** Your email address must be @pdx.edu");
+    }
+
     askQuestionAndSetValue("What is your major?", student::setMajor);
 
     askEnrolledSectionQuestion(student);

--- a/grader/src/test/java/edu/pdx/cs/joy/grader/SurveyTest.java
+++ b/grader/src/test/java/edu/pdx/cs/joy/grader/SurveyTest.java
@@ -7,7 +7,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import java.io.*;
-import java.nio.file.Files;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -58,7 +57,7 @@ public class SurveyTest {
 
   @Test
   void validEmailAddressIsValid() {
-    String address = "whitlock@cs.pdx.edu";
+    String address = "whitlocd@pdx.edu";
     assertThat(Survey.isEmailAddress(address), equalTo(true));
   }
 
@@ -86,7 +85,7 @@ public class SurveyTest {
     String lastName = "Last name";
     String nickName = "Nick name";
     String loginId = "LoginId";
-    String email = "email@email.com";
+    String email = "email@pdx.edu";
     String major = "Major";
     String section = "u";
     String recordGitHubUserName = "y";
@@ -164,4 +163,19 @@ public class SurveyTest {
       return captured.toString();
     }
   }
+
+  @Test
+  void emailAddressIsPdxDotEdu() {
+    Student student = new Student("id");
+    student.setEmail("student@pdx.edu");
+    assertThat(Survey.hasPdxDotEduEmail(student), equalTo(true));
+  }
+
+  @Test
+  void emailAddressIsNotPdxDotEdu() {
+    Student student = new Student("id");
+    student.setEmail("student@gmail.com");
+    assertThat(Survey.hasPdxDotEduEmail(student), equalTo(false));
+  }
+
 }


### PR DESCRIPTION
Require that students provide an `@pdx.edu` email for the `Survey` program.  This fixes #473.