### PR TITLE
Remove DTD URLs

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>examples</artifactId>
   <name>examples</name>
-  <version>1.2.2-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   <url>https://www.cs.pdx.edu/~whitlock</url>
   <dependencies>
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.sun.mail</groupId>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/family/pom.xml
+++ b/family/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
   </dependencies>
   <build>

--- a/grader/pom.xml
+++ b/grader/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>com.opencsv</groupId>

--- a/projects-parent/archetypes-parent/airline-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/pom.xml
@@ -2,7 +2,11 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.github.davidwhitlock.joy.original</groupId>
+  <parent>
+    <artifactId>archetypes-parent</artifactId>
+    <groupId>io.github.davidwhitlock.joy</groupId>
+    <version>2.2.0-SNAPSHOT</version>
+  </parent>
   <artifactId>airline-archetype</artifactId>
   <version>2.2.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
@@ -14,7 +18,7 @@
       <extension>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-packaging</artifactId>
-        <version>3.2.1</version>
+        <version>${maven-archetype-plugin.version}</version>
       </extension>
     </extensions>
 
@@ -22,58 +26,24 @@
       <plugins>
         <plugin>
           <artifactId>maven-archetype-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>${maven-archetype-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
   </build>
 
-  <description>An Airline application for The Joy of Coding at Portland State University</description>
-
-  <url>http://www.cs.pdx.edu/~whitlock</url>
-
-  <developers>
-    <developer>
-      <id>YOU</id>
-      <name>Your name here</name>
-      <email>you@youremail.com</email>
-      <url>http://www.cs.pdx.edu/~YOU</url>
-      <organization>PSU Department of Computer Science</organization>
-      <organizationUrl>http://www.cs.pdx.edu</organizationUrl>
-      <roles>
-        <role>Student</role>
-      </roles>
-      <timezone>-7</timezone>
-    </developer>
-  </developers>
-
-  <licenses>
-    <license>
-      <name>Apache License, Version 2.0</name>
-      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-
-  <scm>
-    <connection>scm:git:git@github.com:JoyOfCodingPDX/JoyOfCoding.git/projects-parent/originals-parent/airline</connection>
-    <developerConnection>scm:git:git@github.com:JoyOfCodingPDX/JoyOfCoding.git/projects-parent/originals-parent/airline</developerConnection>
-    <url>https://github.com/JoyOfCodingPDX/JoyOfCoding/tree/main/projects-parent/originals-parent/airline</url>
-  </scm>
-
-  <distributionManagement>
+  <repositories>
     <repository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-    <snapshotRepository>
-      <id>ossrh</id>
+      <id>maven-snapshots</id>
       <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <site>
-      <id>gh-pages</id>
-      <name>GitHub Pages</name>
-      <url>scm:git:git@github.com:JoyOfCodingPDX/JoyOfCoding.git/projects-parent/originals-parent</url>
-    </site>
-  </distributionManagement>
+      <layout>default</layout>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
 </project>

--- a/projects-parent/archetypes-parent/airline-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/pom.xml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <parent>
-    <artifactId>archetypes-parent</artifactId>
-    <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
-  </parent>
+
+  <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>airline-archetype</artifactId>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>airline-archetype</name>
@@ -17,7 +14,7 @@
       <extension>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-packaging</artifactId>
-        <version>${maven-archetype-plugin.version}</version>
+        <version>3.2.1</version>
       </extension>
     </extensions>
 
@@ -25,24 +22,58 @@
       <plugins>
         <plugin>
           <artifactId>maven-archetype-plugin</artifactId>
-          <version>${maven-archetype-plugin.version}</version>
+          <version>3.2.1</version>
         </plugin>
       </plugins>
     </pluginManagement>
   </build>
 
-  <repositories>
-    <repository>
-      <id>maven-snapshots</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-      <layout>default</layout>
-      <releases>
-        <enabled>false</enabled>
-      </releases>
-      <snapshots>
-        <enabled>true</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
+  <description>An Airline application for The Joy of Coding at Portland State University</description>
 
+  <url>http://www.cs.pdx.edu/~whitlock</url>
+
+  <developers>
+    <developer>
+      <id>YOU</id>
+      <name>Your name here</name>
+      <email>you@youremail.com</email>
+      <url>http://www.cs.pdx.edu/~YOU</url>
+      <organization>PSU Department of Computer Science</organization>
+      <organizationUrl>http://www.cs.pdx.edu</organizationUrl>
+      <roles>
+        <role>Student</role>
+      </roles>
+      <timezone>-7</timezone>
+    </developer>
+  </developers>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <connection>scm:git:git@github.com:JoyOfCodingPDX/JoyOfCoding.git/projects-parent/originals-parent/airline</connection>
+    <developerConnection>scm:git:git@github.com:JoyOfCodingPDX/JoyOfCoding.git/projects-parent/originals-parent/airline</developerConnection>
+    <url>https://github.com/JoyOfCodingPDX/JoyOfCoding/tree/main/projects-parent/originals-parent/airline</url>
+  </scm>
+
+  <distributionManagement>
+    <repository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <site>
+      <id>gh-pages</id>
+      <name>GitHub Pages</name>
+      <url>scm:git:git@github.com:JoyOfCodingPDX/JoyOfCoding.git/projects-parent/originals-parent</url>
+    </site>
+  </distributionManagement>
 </project>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archetype-descriptor xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd" name="airline"
-    xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
+<archetype-descriptor xsi:schemaLocation="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0 http://maven.apache.org/xsd/archetype-descriptor-1.1.0.xsd" name="airline"
+    xmlns="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <fileSets>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -111,11 +111,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <version>4.0.0-M13</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
         <version>${maven-surefire-report-plugin.version}</version>
       </plugin>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -111,6 +111,11 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>4.0.0-M13</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
         <version>${maven-surefire-report-plugin.version}</version>
       </plugin>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/java/AirlineXmlHelper.java
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/java/AirlineXmlHelper.java
@@ -11,16 +11,12 @@ import edu.pdx.cs.joy.ProjectXmlHelper;
  */
 public class AirlineXmlHelper extends ProjectXmlHelper {
 
-  /** The System ID for the Family Tree DTD */
-  protected static final String SYSTEM_ID =
-    "http://www.cs.pdx.edu/~whitlock/dtds/airline.dtd";
-
   /** The Public ID for the Family Tree DTD */
   protected static final String PUBLIC_ID =
     "-//Joy of Coding at PSU//DTD Airline//EN";
 
 
   public AirlineXmlHelper() {
-    super(PUBLIC_ID, SYSTEM_ID, "airline.dtd");
+    super(PUBLIC_ID, "airline.dtd");
   }
 }

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/java/TextDumper.java
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/java/TextDumper.java
@@ -5,7 +5,6 @@ package ${package};
 
 import edu.pdx.cs.joy.AirlineDumper;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/java/TextParser.java
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/java/TextParser.java
@@ -8,7 +8,6 @@ import edu.pdx.cs.joy.ParserException;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.io.Reader;
 
 /**

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/javadoc/edu/pdx/cs410J/__artifactId__/package.html
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/main/javadoc/edu/pdx/cs410J/__artifactId__/package.html
@@ -1,0 +1,6 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<body>
+    <p>Contains the application classes for the Airline project.</p>
+</body>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/test/javadoc/edu/pdx/cs410J/__artifactId__/package.html
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/test/javadoc/edu/pdx/cs410J/__artifactId__/package.html
@@ -1,0 +1,6 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<body>
+    <p>Contains the test classes for the Airline project.</p>
+</body>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/test/resources/__packageInPathFormat__/invalid-airline.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/test/resources/__packageInPathFormat__/invalid-airline.xml
@@ -5,7 +5,7 @@
 
 <!-- A sample airline XML file -->
 <!DOCTYPE airline
-          SYSTEM "http://www.cs.pdx.edu/~whitlock/dtds/airline.dtd">
+        PUBLIC "-//Joy of Coding at PSU//DTD Airline//EN" "airline.dtd">
 
 <airline>
   <name>Example Airlines</name>
@@ -13,26 +13,26 @@
     <number>1437</number>
     <src>BJX</src>
     <depart>
-      <date day="25" month="9" year="2020"/>
+      <date day="25" month="9" year="2024"/>
       <!-- Missing time -->
     </depart>
     <dest>CMN</dest> <!-- They're taking me to Marrakesh! -->
     <arrive>
-      <date day="26" month="9" year="2020"/>
-      <time hour="3" minute="56" time-zone="America/Los_Angeles"/>
+      <date day="26" month="9" year="2024"/>
+      <time hour="3" minute="56"/>
     </arrive>
   </flight>
   <flight>
     <number>7865</number>
     <src>JNB</src>
     <depart>
-      <date day="15" month="5" year="2020"/>
-      <time hour="7" minute="24" time-zone="America/Los_Angeles"/>
+      <date day="15" month="5" year="2024"/>
+      <time hour="7" minute="24"/>
     </depart>
     <dest>XIY</dest>
     <arrive>
-      <date day="16" month="5" year="2020"/>
-      <time hour="9" minute="7" time-zone="America/Los_Angeles"/>
+      <date day="16" month="5" year="2024"/>
+      <time hour="9" minute="7"/>
     </arrive>
   </flight>
 </airline>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/test/resources/__packageInPathFormat__/valid-airline.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/src/test/resources/__packageInPathFormat__/valid-airline.xml
@@ -4,7 +4,7 @@
 <?xml version='1.0' encoding='us-ascii'?>
 
 <!DOCTYPE airline
-          SYSTEM "http://www.cs.pdx.edu/~whitlock/dtds/airline.dtd">
+        PUBLIC "-//Joy of Coding at PSU//DTD Airline//EN" "airline.dtd">
 
 <airline>
   <name>Valid Airlines</name>
@@ -12,26 +12,26 @@
     <number>1437</number>
     <src>BJX</src>
     <depart>
-      <date day="25" month="9" year="2020"/>
-      <time hour="17" minute="0" time-zone="America/Los_Angeles"/>
+      <date day="25" month="9" year="2024"/>
+      <time hour="17" minute="0"/>
     </depart>
     <dest>CMN</dest> <!-- They're taking me to Marrakesh! -->
     <arrive>
-      <date day="26" month="9" year="2020"/>
-      <time hour="3" minute="56" time-zone="America/Los_Angeles"/>
+      <date day="26" month="9" year="2024"/>
+      <time hour="3" minute="56"/>
     </arrive>
   </flight>
   <flight>
     <number>7865</number>
     <src>JNB</src>
     <depart>
-      <date day="15" month="5" year="2020"/>
-      <time hour="7" minute="24" time-zone="America/Los_Angeles"/>
+      <date day="15" month="5" year="2024"/>
+      <time hour="7" minute="24"/>
     </depart>
     <dest>XIY</dest>
     <arrive>
-      <date day="16" month="5" year="2020"/>
-      <time hour="9" minute="7" time-zone="America/Los_Angeles"/>
+      <date day="16" month="5" year="2024"/>
+      <time hour="9" minute="7"/>
     </arrive>
   </flight>
 </airline>

--- a/projects-parent/archetypes-parent/airline-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/projects-parent/archetypes-parent/airline-archetype/src/test/resources/projects/basic/archetype.properties
@@ -1,5 +1,5 @@
-#Fri Nov 27 14:58:27 PST 2015
+#Sun Nov 17 19:26:52 PST 2024
 package=it.pkg
-version=0.1-SNAPSHOT
 groupId=archetype.it
 artifactId=basic
+version=0.1-SNAPSHOT

--- a/projects-parent/archetypes-parent/airline-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>airline-web-archetype</artifactId>
   <version>2.3.0-SNAPSHOT</version>

--- a/projects-parent/archetypes-parent/airline-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/pom.xml
@@ -7,7 +7,7 @@
     <version>2.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>airline-web-archetype</artifactId>
-  <version>2.2.2-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>airline-web-archetype</name>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.2.2-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/apptbook-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/pom.xml
@@ -17,7 +17,7 @@
       <extension>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-packaging</artifactId>
-        <version>3.2.1</version>
+        <version>${maven-archetype-plugin.version}</version>
       </extension>
     </extensions>
 
@@ -25,7 +25,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-archetype-plugin</artifactId>
-          <version>3.2.1</version>
+          <version>${maven-archetype-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/projects-parent/archetypes-parent/apptbook-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/pom.xml
@@ -7,7 +7,7 @@
     <version>2.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>apptbook-archetype</artifactId>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>apptbook-archetype</name>
@@ -17,7 +17,7 @@
       <extension>
         <groupId>org.apache.maven.archetype</groupId>
         <artifactId>archetype-packaging</artifactId>
-        <version>${maven-archetype-plugin.version}</version>
+        <version>3.2.1</version>
       </extension>
     </extensions>
 
@@ -25,7 +25,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-archetype-plugin</artifactId>
-          <version>${maven-archetype-plugin.version}</version>
+          <version>3.2.1</version>
         </plugin>
       </plugins>
     </pluginManagement>

--- a/projects-parent/archetypes-parent/apptbook-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>apptbook-archetype</artifactId>
   <version>2.2.0-SNAPSHOT</version>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookXmlHelper.java
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookXmlHelper.java
@@ -8,18 +8,12 @@ import edu.pdx.cs.joy.ProjectXmlHelper;
 public class AppointmentBookXmlHelper extends ProjectXmlHelper {
 
   /**
-   * The System ID for the Family Tree DTD
-   */
-  protected static final String SYSTEM_ID =
-    "http://www.cs.pdx.edu/~whitlock/dtds/apptbook.dtd";
-
-  /**
    * The Public ID for the Family Tree DTD
    */
   protected static final String PUBLIC_ID =
     "-//Joy of Coding at PSU//DTD Appointment Book//EN";
 
   protected AppointmentBookXmlHelper() {
-    super(PUBLIC_ID, SYSTEM_ID, "apptbook.dtd");
+    super(PUBLIC_ID, "apptbook.dtd");
   }
 }

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/main/java/TextParser.java
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/main/java/TextParser.java
@@ -7,7 +7,6 @@ import edu.pdx.cs.joy.AppointmentBookParser;
 import edu.pdx.cs.joy.ParserException;
 
 import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
 

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/main/javadoc/edu/pdx/cs410J/__artifactId__/package.html
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/main/javadoc/edu/pdx/cs410J/__artifactId__/package.html
@@ -1,0 +1,6 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<body>
+    <p>Contains the application classes for the Appointment Book project.</p>
+</body>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/test/javadoc/edu/pdx/cs410J/__artifactId__/package.html
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/test/javadoc/edu/pdx/cs410J/__artifactId__/package.html
@@ -1,0 +1,6 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+<body>
+    <p>Contains the test classes for the Appointment Book project.</p>
+</body>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/test/resources/__packageInPathFormat__/invalid-apptbook.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/test/resources/__packageInPathFormat__/invalid-apptbook.xml
@@ -4,14 +4,14 @@
 <?xml version='1.0' encoding='us-ascii'?>
 
 <!DOCTYPE apptbook
-        SYSTEM "http://www.cs.pdx.edu/~whitlock/dtds/apptbook.dtd">
+        PUBLIC "-//Joy of Coding at PSU//DTD Appointment Book//EN" "apptbook.dtd">
 
 <apptbook>
   <owner>Example Appointment Book</owner>
   <appt>
     <begin>
       <date day="11" month="10" year="2023"/>
-      <time hour="13" minute="6" time-zone="America/Los_Angeles"/>
+      <time hour="13" minute="6"/>
     </begin>
     <end>
       <date day="11" month="10" year="2023"/>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/test/resources/__packageInPathFormat__/valid-apptbook.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/src/test/resources/__packageInPathFormat__/valid-apptbook.xml
@@ -4,18 +4,18 @@
 <?xml version='1.0' encoding='us-ascii'?>
 
 <!DOCTYPE apptbook
-          SYSTEM "http://www.cs.pdx.edu/~whitlock/dtds/apptbook.dtd">
+        PUBLIC "-//Joy of Coding at PSU//DTD Appointment Book//EN" "apptbook.dtd">
 
 <apptbook>
   <owner>Example Appointment Book</owner>
   <appt>
     <begin>
       <date day="11" month="10" year="2023"/>
-      <time hour="13" minute="6" time-zone="America/Los_Angeles"/>
+      <time hour="13" minute="6"/>
     </begin>
     <end>
       <date day="11" month="10" year="2023"/>
-      <time hour="14" minute="0" time-zone="America/Los_Angeles"/>
+      <time hour="14" minute="0"/>
     </end>
     <description>Example Appointment</description>
   </appt>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/test/resources/projects/basic/archetype.properties
@@ -1,4 +1,4 @@
-#Sat Nov 11 08:26:12 PST 2023
+#Sun Nov 17 19:44:35 PST 2024
 package=it.pkg
 groupId=archetype.it
 artifactId=basic

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>apptbook-web-archetype</artifactId>
   <version>2.3.0-SNAPSHOT</version>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
@@ -7,7 +7,7 @@
     <version>2.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>apptbook-web-archetype</artifactId>
-  <version>2.2.2-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>apptbook-web-archetype</name>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.2.2-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
@@ -9,7 +9,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>java-koans-archetype</artifactId>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>java-koans-archetype</name>

--- a/projects-parent/archetypes-parent/kata-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/kata-archetype/pom.xml
@@ -8,7 +8,7 @@
     <version>2.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>kata-archetype</artifactId>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>kata-archetype</name>

--- a/projects-parent/archetypes-parent/kata-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/kata-archetype/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>kata-archetype</artifactId>
   <version>2.2.0-SNAPSHOT</version>

--- a/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/phonebill-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>phonebill-archetype</artifactId>

--- a/projects-parent/archetypes-parent/phonebill-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/pom.xml
@@ -7,7 +7,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>phonebill-archetype</artifactId>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>phonebill-archetype</name>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>phonebill-web-archetype</artifactId>
   <version>2.3.0-SNAPSHOT</version>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
@@ -7,7 +7,7 @@
     <version>2.1.1-SNAPSHOT</version>
   </parent>
   <artifactId>phonebill-web-archetype</artifactId>
-  <version>2.2.2-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>phonebill-web-archetype</name>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.2.2-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>

--- a/projects-parent/archetypes-parent/pom.xml
+++ b/projects-parent/archetypes-parent/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.github.davidwhitlock.joy</groupId>
         <artifactId>projects-parent</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>archetypes-parent</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/projects-parent/archetypes-parent/student-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>student-archetype</artifactId>

--- a/projects-parent/archetypes-parent/student-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>student-archetype</artifactId>
-  <version>2.2.2-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>Archetype for Student project</name>

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId> <!-- For the Human class -->
-      <version>1.2.2-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.2.2-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>airline-web</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
 
   <properties>
     <jetty.http.port>8080</jetty.http.port>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/airline/pom.xml
+++ b/projects-parent/originals-parent/airline/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>airline</artifactId>
   <packaging>jar</packaging>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <name>Airline Project</name>
   <description>An Airline application for The Joy of Coding at Portland State University</description>
   <inceptionYear>2000</inceptionYear>
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/airline/src/main/java/edu/pdx/cs/joy/airline/AirlineXmlHelper.java
+++ b/projects-parent/originals-parent/airline/src/main/java/edu/pdx/cs/joy/airline/AirlineXmlHelper.java
@@ -8,16 +8,12 @@ import edu.pdx.cs.joy.ProjectXmlHelper;
  */
 public class AirlineXmlHelper extends ProjectXmlHelper {
 
-  /** The System ID for the Family Tree DTD */
-  protected static final String SYSTEM_ID =
-    "http://www.cs.pdx.edu/~whitlock/dtds/airline.dtd";
-
   /** The Public ID for the Family Tree DTD */
   protected static final String PUBLIC_ID =
     "-//Joy of Coding at PSU//DTD Airline//EN";
 
 
   public AirlineXmlHelper() {
-    super(PUBLIC_ID, SYSTEM_ID, "airline.dtd");
+    super(PUBLIC_ID, "airline.dtd");
   }
 }

--- a/projects-parent/originals-parent/airline/src/test/resources/edu/pdx/cs/joy/airline/invalid-airline.xml
+++ b/projects-parent/originals-parent/airline/src/test/resources/edu/pdx/cs/joy/airline/invalid-airline.xml
@@ -2,7 +2,7 @@
 
 <!-- A sample airline XML file -->
 <!DOCTYPE airline
-          SYSTEM "http://www.cs.pdx.edu/~whitlock/dtds/airline.dtd">
+        PUBLIC "-//Joy of Coding at PSU//DTD Airline//EN" "airline.dtd">
 
 <airline>
   <name>Example Airlines</name>
@@ -10,26 +10,26 @@
     <number>1437</number>
     <src>BJX</src>
     <depart>
-      <date day="25" month="9" year="2020"/>
+      <date day="25" month="9" year="2024"/>
       <!-- Missing time -->
     </depart>
     <dest>CMN</dest> <!-- They're taking me to Marrakesh! -->
     <arrive>
-      <date day="26" month="9" year="2020"/>
-      <time hour="3" minute="56" time-zone="America/Los_Angeles"/>
+      <date day="26" month="9" year="2024"/>
+      <time hour="3" minute="56"/>
     </arrive>
   </flight>
   <flight>
     <number>7865</number>
     <src>JNB</src>
     <depart>
-      <date day="15" month="5" year="2020"/>
-      <time hour="7" minute="24"  time-zone="America/Los_Angeles"/>
+      <date day="15" month="5" year="2024"/>
+      <time hour="7" minute="24"/>
     </depart>
     <dest>XIY</dest>
     <arrive>
-      <date day="16" month="5" year="2020"/>
-      <time hour="9" minute="7" time-zone="America/Los_Angeles"/>
+      <date day="16" month="5" year="2024"/>
+      <time hour="9" minute="7"/>
     </arrive>
   </flight>
 </airline>

--- a/projects-parent/originals-parent/airline/src/test/resources/edu/pdx/cs/joy/airline/valid-airline.xml
+++ b/projects-parent/originals-parent/airline/src/test/resources/edu/pdx/cs/joy/airline/valid-airline.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='us-ascii'?>
 
 <!DOCTYPE airline
-          SYSTEM "http://www.cs.pdx.edu/~whitlock/dtds/airline.dtd">
+          PUBLIC "-//Joy of Coding at PSU//DTD Airline//EN" "airline.dtd">
 
 <airline>
   <name>Valid Airlines</name>
@@ -9,26 +9,26 @@
     <number>1437</number>
     <src>BJX</src>
     <depart>
-      <date day="25" month="9" year="2020"/>
-      <time hour="17" minute="0" time-zone="America/Los_Angeles"/>
+      <date day="25" month="9" year="2024"/>
+      <time hour="17" minute="0"/>
     </depart>
     <dest>CMN</dest> <!-- They're taking me to Marrakesh! -->
     <arrive>
-      <date day="26" month="9" year="2020"/>
-      <time hour="3" minute="56" time-zone="America/Los_Angeles"/>
+      <date day="26" month="9" year="2024"/>
+      <time hour="3" minute="56"/>
     </arrive>
   </flight>
   <flight>
     <number>7865</number>
     <src>JNB</src>
     <depart>
-      <date day="15" month="5" year="2020"/>
-      <time hour="7" minute="24" time-zone="America/Los_Angeles"/>
+      <date day="15" month="5" year="2024"/>
+      <time hour="7" minute="24"/>
     </depart>
     <dest>XIY</dest>
     <arrive>
-      <date day="16" month="5" year="2020"/>
-      <time hour="9" minute="7" time-zone="America/Los_Angeles"/>
+      <date day="16" month="5" year="2024"/>
+      <time hour="9" minute="7"/>
     </arrive>
   </flight>
 </airline>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.2.2-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>apptbook-web</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
 
   <properties>
     <jetty.http.port>8080</jetty.http.port>
@@ -21,7 +21,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/apptbook/pom.xml
+++ b/projects-parent/originals-parent/apptbook/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>apptbook</artifactId>
   <packaging>jar</packaging>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <name>Appointment Book Project</name>
   <description>An Appointment Book application for The Joy of Coding at Portland State University</description>
   <inceptionYear>2000</inceptionYear>
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/apptbook/src/main/java/edu/pdx/cs/joy/apptbook/AppointmentBookXmlHelper.java
+++ b/projects-parent/originals-parent/apptbook/src/main/java/edu/pdx/cs/joy/apptbook/AppointmentBookXmlHelper.java
@@ -5,18 +5,12 @@ import edu.pdx.cs.joy.ProjectXmlHelper;
 public class AppointmentBookXmlHelper extends ProjectXmlHelper {
 
   /**
-   * The System ID for the Family Tree DTD
-   */
-  protected static final String SYSTEM_ID =
-    "http://www.cs.pdx.edu/~whitlock/dtds/apptbook.dtd";
-
-  /**
    * The Public ID for the Family Tree DTD
    */
   protected static final String PUBLIC_ID =
     "-//Joy of Coding at PSU//DTD Appointment Book//EN";
 
   protected AppointmentBookXmlHelper() {
-    super(PUBLIC_ID, SYSTEM_ID, "apptbook.dtd");
+    super(PUBLIC_ID, "apptbook.dtd");
   }
 }

--- a/projects-parent/originals-parent/apptbook/src/test/resources/edu/pdx/cs/joy/apptbook/invalid-apptbook.xml
+++ b/projects-parent/originals-parent/apptbook/src/test/resources/edu/pdx/cs/joy/apptbook/invalid-apptbook.xml
@@ -1,14 +1,14 @@
 <?xml version='1.0' encoding='us-ascii'?>
 
 <!DOCTYPE apptbook
-        SYSTEM "http://www.cs.pdx.edu/~whitlock/dtds/apptbook.dtd">
+        PUBLIC "-//Joy of Coding at PSU//DTD Appointment Book//EN" "apptbook.dtd">
 
 <apptbook>
   <owner>Example Appointment Book</owner>
   <appt>
     <begin>
       <date day="11" month="10" year="2023"/>
-      <time hour="13" minute="6" time-zone="America/Los_Angeles"/>
+      <time hour="13" minute="6"/>
     </begin>
     <end>
       <date day="11" month="10" year="2023"/>

--- a/projects-parent/originals-parent/apptbook/src/test/resources/edu/pdx/cs/joy/apptbook/valid-apptbook.xml
+++ b/projects-parent/originals-parent/apptbook/src/test/resources/edu/pdx/cs/joy/apptbook/valid-apptbook.xml
@@ -1,18 +1,18 @@
 <?xml version='1.0' encoding='us-ascii'?>
 
 <!DOCTYPE apptbook
-          SYSTEM "http://www.cs.pdx.edu/~whitlock/dtds/apptbook.dtd">
+          PUBLIC "-//Joy of Coding at PSU//DTD Appointment Book//EN" "apptbook.dtd">
 
 <apptbook>
   <owner>Example Appointment Book</owner>
   <appt>
     <begin>
       <date day="11" month="10" year="2023"/>
-      <time hour="13" minute="6" time-zone="America/Los_Angeles"/>
+      <time hour="13" minute="6"/>
     </begin>
     <end>
       <date day="11" month="10" year="2023"/>
-      <time hour="14" minute="0" time-zone="America/Los_Angeles"/>
+      <time hour="14" minute="0"/>
     </end>
     <description>Example Appointment</description>
   </appt>

--- a/projects-parent/originals-parent/kata/pom.xml
+++ b/projects-parent/originals-parent/kata/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>kata</artifactId>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Kata Project</name>
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>phonebill-web</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.3.0-SNAPSHOT</version>
 
   <properties>
     <jetty.http.port>8080</jetty.http.port>
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.2.2-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>

--- a/projects-parent/originals-parent/phonebill/pom.xml
+++ b/projects-parent/originals-parent/phonebill/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>phonebill</artifactId>
   <packaging>jar</packaging>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <name>Phone Bill Project</name>
   <description>A Phone Bill application for The Joy of Coding at Portland State University</description>
   <inceptionYear>2000</inceptionYear>
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/pom.xml
+++ b/projects-parent/originals-parent/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>io.github.davidwhitlock.joy</groupId>
         <artifactId>projects-parent</artifactId>
-        <version>2.1.1-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>originals-parent</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/projects-parent/originals-parent/student/pom.xml
+++ b/projects-parent/originals-parent/student/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>student</artifactId>
-  <version>2.2.1-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Student Project</name>
@@ -93,7 +93,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>2.1.1-SNAPSHOT</version>
+      <version>3.0.0-SNAPSHOT</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/student/pom.xml
+++ b/projects-parent/originals-parent/student/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId> <!-- For the Human class -->
-      <version>1.2.2-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>

--- a/projects-parent/pom.xml
+++ b/projects-parent/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>projects-parent</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <packaging>pom</packaging>
 

--- a/projects-parent/projects/pom.xml
+++ b/projects-parent/projects/pom.xml
@@ -2,13 +2,13 @@
   <parent>
     <artifactId>projects-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>projects</artifactId>
   <name>Project APIs</name>
   <description>Classes needed for the Projects in The Joy of Coding</description>
-  <version>2.1.1-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <build>
     <plugins>

--- a/projects-parent/projects/src/main/java/edu/pdx/cs/joy/ProjectXmlHelper.java
+++ b/projects-parent/projects/src/main/java/edu/pdx/cs/joy/ProjectXmlHelper.java
@@ -8,12 +8,10 @@ import java.net.URL;
 
 public abstract class ProjectXmlHelper implements ErrorHandler, EntityResolver {
   private final String publicId;
-  private final String systemId;
   private final String dtdFileName;
 
-  protected ProjectXmlHelper(String publicId, String systemId, String dtdFileName) {
+  protected ProjectXmlHelper(String publicId, String dtdFileName) {
     this.publicId = publicId;
-    this.systemId = systemId;
     this.dtdFileName = dtdFileName;
   }
 
@@ -34,7 +32,7 @@ public abstract class ProjectXmlHelper implements ErrorHandler, EntityResolver {
 
   @Override
   public InputSource resolveEntity(String publicId, String systemId) throws SAXException, IOException {
-    if (this.publicId.equals(publicId) || this.systemId.equals(systemId)) {
+    if (this.publicId.equals(publicId)) {
       // We're resolving the external entity for the DTD
       // Check to see if it's in the jar file.  This way we don't
       // need to go all the way to the website to find the DTD.
@@ -45,14 +43,6 @@ public abstract class ProjectXmlHelper implements ErrorHandler, EntityResolver {
       }
     }
 
-    // Try to access the DTD using the URL
-    try {
-      URL url = new URL(systemId);
-      InputStream stream = url.openStream();
-      return new InputSource(stream);
-
-    } catch (Exception ex) {
-      return null;
-    }
+    return null;
   }
 }

--- a/projects-parent/projects/src/main/java/edu/pdx/cs/joy/airline.xml
+++ b/projects-parent/projects/src/main/java/edu/pdx/cs/joy/airline.xml
@@ -2,7 +2,7 @@
 
 <!-- A sample airline XML file -->
 <!DOCTYPE airline
-          SYSTEM "http://www.cs.pdx.edu/~whitlock/dtds/airline.dtd">
+        PUBLIC "-//Joy of Coding at PSU//DTD Airline//EN" "airline.dtd">
 
 <airline>
   <name>Example Airlines</name>

--- a/projects-parent/projects/src/main/resources/edu/pdx/cs/joy/airline.dtd
+++ b/projects-parent/projects/src/main/resources/edu/pdx/cs/joy/airline.dtd
@@ -40,5 +40,4 @@
 <!ATTLIST time
           hour       CDATA  #REQUIRED
           minute     CDATA  #REQUIRED
-          time-zone  CDATA  #REQUIRED
 >

--- a/projects-parent/projects/src/main/resources/edu/pdx/cs/joy/apptbook.dtd
+++ b/projects-parent/projects/src/main/resources/edu/pdx/cs/joy/apptbook.dtd
@@ -37,6 +37,5 @@
 <!ATTLIST time
           hour       CDATA  #REQUIRED
           minute     CDATA  #REQUIRED
-          time-zone  CDATA  #REQUIRED
 >
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>web</artifactId>
   <packaging>war</packaging>
   <name>Web Application examples</name>
-  <version>1.2.2-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <properties>
     <resteasy.version>6.2.8.Final</resteasy.version>
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.2.2-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>jakarta.xml.bind</groupId>


### PR DESCRIPTION
Remove references to the URLs for XML DTDs because attempting to load the URLs now returns an HTTP 403.  This made a change to the `projects` API which was not backward compatible.  As a result, version numbers got bumped.