### PR TITLE
Issue 404/jetty 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
 
         <guava.version>33.3.1-jre</guava.version>
         <guice.version>7.0.0</guice.version>
+        <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <maven.compiler.target>17</maven.compiler.target>
 
         <guava.version>33.3.1-jre</guava.version>
-        <guice.version>5.1.0</guice.version>
+        <guice.version>7.0.0</guice.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -74,7 +74,7 @@
       <maven-jar-plugin.version>3.4.2</maven-jar-plugin.version>
       <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
       <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-      <jetty-maven-plugin.version>10.0.24</jetty-maven-plugin.version>
+      <jetty-maven-plugin.version>11.0.24</jetty-maven-plugin.version>
       <spotbugs-maven-plugin.version>4.8.6.6</spotbugs-maven-plugin.version>
       <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
       <maven-shade-plugin.version>3.6.0</maven-shade-plugin.version>

--- a/projects-parent/archetypes-parent/airline-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/pom.xml
@@ -7,7 +7,7 @@
     <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>airline-web-archetype</artifactId>
-  <version>2.3.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>airline-web-archetype</name>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archetype-descriptor xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd" name="airline-web"
-    xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
+<archetype-descriptor xsi:schemaLocation="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0 https://maven.apache.org/xsd/archetype-descriptor-1.1.0.xsd" name="airline-web"
+    xmlns="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <fileSets>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -8,13 +8,13 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
+  <version>${version}</version>
 
   <properties>
     <jetty.http.port>8080</jetty.http.port>
   </properties>
 
   <packaging>war</packaging>
-  <version>${version}</version>
   <name>Airline Web/REST Project</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -36,9 +36,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet-api.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/AirlineRestClient.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/AirlineRestClient.java
@@ -6,13 +6,13 @@ package ${package};
 import com.google.common.annotations.VisibleForTesting;
 import edu.pdx.cs.joy.ParserException;
 import edu.pdx.cs.joy.web.HttpRequestHelper;
+import edu.pdx.cs.joy.web.HttpRequestHelper.Response;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Map;
 
-import static edu.pdx.cs.joy.web.HttpRequestHelper.Response;
-import static edu.pdx.cs.joy.web.HttpRequestHelper.RestException;
+import static edu.pdx.cs.joy.web.HttpRequestHelper.*;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 /**

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/AirlineServlet.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/java/AirlineServlet.java
@@ -5,9 +5,9 @@ package ${package};
 
 import com.google.common.annotations.VisibleForTesting;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/webapp/error.jsp
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/main/webapp/error.jsp
@@ -2,4 +2,4 @@
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
 <%@ page contentType="text/plain;charset=UTF-8" language="java" isErrorPage="true" %>
-<%out.println( request.getAttribute("javax.servlet.error.message") );%>
+<%out.println( request.getAttribute("jakarta.servlet.error.message") );%>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/test/java/AirlineRestClientTest.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/test/java/AirlineRestClientTest.java
@@ -14,7 +14,8 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * A unit test for the REST client that demonstrates using mocks and

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/test/java/AirlineServletTest.java
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/src/test/java/AirlineServletTest.java
@@ -6,8 +6,8 @@ package ${package};
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/test/resources/projects/basic/archetype.properties
@@ -1,5 +1,5 @@
-#Sat Dec 05 20:02:17 PST 2015
+#Fri Nov 29 09:22:12 PST 2024
 package=it.pkg
-version=0.1-SNAPSHOT
 groupId=archetype.it
 artifactId=basic
+version=0.1-SNAPSHOT

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
@@ -7,7 +7,7 @@
     <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>apptbook-web-archetype</artifactId>
-  <version>2.3.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>apptbook-web-archetype</name>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archetype-descriptor xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd" name="apptbook-web"
-    xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
+<archetype-descriptor xsi:schemaLocation="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0 https://maven.apache.org/xsd/archetype-descriptor-1.1.0.xsd" name="apptbook-web"
+    xmlns="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <fileSets>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
-    <artifactId>joy</artifactId>
+    <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
+  <version>${version}</version>
 
   <properties>
     <jetty.http.port>8080</jetty.http.port>
   </properties>
 
   <packaging>war</packaging>
-  <version>${version}</version>
   <name>Appointment Book Web/REST Project</name>
   <url>http://maven.apache.org</url>
   <dependencies>
@@ -36,9 +36,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet-api.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
-    <artifactId>originals-parent</artifactId>
+    <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/AppointmentBookRestClientIT.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/it/java/AppointmentBookRestClientIT.java
@@ -60,8 +60,7 @@ class AppointmentBookRestClientIT {
     AppointmentBookRestClient client = newAppointmentBookRestClient();
     String emptyString = "";
 
-    RestException ex =
-      assertThrows(RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
+    RestException ex = assertThrows(RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
     assertThat(ex.getHttpStatusCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
     assertThat(ex.getMessage(), containsString(Messages.missingRequiredParameter(AppointmentBookServlet.WORD_PARAMETER)));  }
 

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookRestClient.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookRestClient.java
@@ -4,15 +4,15 @@
 package ${package};
 
 import com.google.common.annotations.VisibleForTesting;
-import edu.pdx.cs.joy.ParserException;
 import edu.pdx.cs.joy.web.HttpRequestHelper;
+import edu.pdx.cs.joy.ParserException;
+import edu.pdx.cs.joy.web.HttpRequestHelper.Response;
+import edu.pdx.cs.joy.web.HttpRequestHelper.RestException;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Map;
 
-import static edu.pdx.cs.joy.web.HttpRequestHelper.Response;
-import static edu.pdx.cs.joy.web.HttpRequestHelper.RestException;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 /**

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookServlet.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/java/AppointmentBookServlet.java
@@ -5,9 +5,9 @@ package ${package};
 
 import com.google.common.annotations.VisibleForTesting;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/webapp/error.jsp
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/main/webapp/error.jsp
@@ -2,4 +2,4 @@
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
 <%@ page contentType="text/plain;charset=UTF-8" language="java" isErrorPage="true" %>
-<%out.println( request.getAttribute("javax.servlet.error.message") );%>
+<%out.println( request.getAttribute("jakarta.servlet.error.message") );%>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/test/java/AppointmentBookServletTest.java
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/src/test/java/AppointmentBookServletTest.java
@@ -6,9 +6,9 @@ package ${package};
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/test/resources/projects/basic/archetype.properties
@@ -1,4 +1,4 @@
-#Mon Nov 22 19:43:39 PST 2021
+#Fri Nov 29 10:10:43 PST 2024
 package=it.pkg
 groupId=archetype.it
 artifactId=basic

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
@@ -7,7 +7,7 @@
     <version>2.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>phonebill-web-archetype</artifactId>
-  <version>2.3.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
   <packaging>maven-archetype</packaging>
 
   <name>phonebill-web-archetype</name>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archetype-descriptor xsi:schemaLocation="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0 http://maven.apache.org/xsd/archetype-descriptor-1.0.0.xsd" name="phonebill-web"
-    xmlns="http://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.0.0"
+<archetype-descriptor xsi:schemaLocation="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0 https://maven.apache.org/xsd/archetype-descriptor-1.1.0.xsd" name="phonebill-web"
+    xmlns="https://maven.apache.org/plugins/maven-archetype-plugin/archetype-descriptor/1.1.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <fileSets>
     <fileSet filtered="true" packaged="true" encoding="UTF-8">

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
-    <artifactId>originals-parent</artifactId>
+    <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <parent>
-    <artifactId>joy</artifactId>
+    <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
+  <version>${version}</version>
 
   <properties>
     <jetty.http.port>8080</jetty.http.port>
   </properties>
 
   <packaging>war</packaging>
-  <version>${version}</version>
   <name>Phone Bill Web/REST Project</name>
-  <url>http://maven.apache.org</url>
+  <url>https://maven.apache.org</url>
 
   <dependencies>
     <dependency>
@@ -37,9 +37,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet-api.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/PhoneBillRestClientIT.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/it/java/PhoneBillRestClientIT.java
@@ -60,8 +60,7 @@ class PhoneBillRestClientIT {
     PhoneBillRestClient client = newPhoneBillRestClient();
     String emptyString = "";
 
-    RestException ex =
-      assertThrows(RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
+    RestException ex = assertThrows(RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
     assertThat(ex.getHttpStatusCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
     assertThat(ex.getMessage(), containsString(Messages.missingRequiredParameter(PhoneBillServlet.WORD_PARAMETER)));
   }

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PhoneBillRestClient.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PhoneBillRestClient.java
@@ -6,13 +6,13 @@ package ${package};
 import com.google.common.annotations.VisibleForTesting;
 import edu.pdx.cs.joy.ParserException;
 import edu.pdx.cs.joy.web.HttpRequestHelper;
+import edu.pdx.cs.joy.web.HttpRequestHelper.Response;
+import edu.pdx.cs.joy.web.HttpRequestHelper.RestException;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Map;
 
-import static edu.pdx.cs.joy.web.HttpRequestHelper.Response;
-import static edu.pdx.cs.joy.web.HttpRequestHelper.RestException;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 /**

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PhoneBillServlet.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/PhoneBillServlet.java
@@ -5,9 +5,9 @@ package ${package};
 
 import com.google.common.annotations.VisibleForTesting;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/Project4.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/java/Project4.java
@@ -4,7 +4,6 @@
 package ${package};
 
 import edu.pdx.cs.joy.ParserException;
-import edu.pdx.cs.joy.web.HttpRequestHelper;
 
 import java.io.IOException;
 import java.io.PrintStream;

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/webapp/error.jsp
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/main/webapp/error.jsp
@@ -2,4 +2,4 @@
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
 <%@ page contentType="text/plain;charset=UTF-8" language="java" isErrorPage="true" %>
-<%out.println( request.getAttribute("javax.servlet.error.message") );%>
+<%out.println( request.getAttribute("jakarta.servlet.error.message") );%>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/test/java/PhoneBillRestClientTest.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/test/java/PhoneBillRestClientTest.java
@@ -5,6 +5,7 @@ package ${package};
 
 import edu.pdx.cs.joy.ParserException;
 import edu.pdx.cs.joy.web.HttpRequestHelper;
+import edu.pdx.cs.joy.web.HttpRequestHelper.Response;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -31,10 +32,10 @@ public class PhoneBillRestClientTest {
     assertThat(client.getAllDictionaryEntries(), equalTo(dictionary));
   }
 
-  private HttpRequestHelper.Response dictionaryAsText(Map<String, String> dictionary) {
+  private Response dictionaryAsText(Map<String, String> dictionary) {
     StringWriter writer = new StringWriter();
     new TextDumper(writer).dump(dictionary);
 
-    return new HttpRequestHelper.Response(writer.toString());
+    return new Response(writer.toString());
   }
 }

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/test/java/PhoneBillServletTest.java
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/src/test/java/PhoneBillServletTest.java
@@ -6,9 +6,9 @@ package ${package};
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/test/resources/projects/basic/archetype.properties
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/test/resources/projects/basic/archetype.properties
@@ -1,5 +1,5 @@
-#Fri Nov 27 15:58:35 PST 2015
+#Fri Nov 29 10:23:40 PST 2024
 package=it.pkg
-version=0.1-SNAPSHOT
 groupId=archetype.it
 artifactId=basic
+version=0.1-SNAPSHOT

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>airline-web</artifactId>
-  <version>2.3.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
 
   <properties>
     <jetty.http.port>8080</jetty.http.port>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -36,9 +36,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet-api.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs/joy/airlineweb/AirlineRestClientIT.java
+++ b/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs/joy/airlineweb/AirlineRestClientIT.java
@@ -1,7 +1,7 @@
 package edu.pdx.cs.joy.airlineweb;
 
-import edu.pdx.cs.joy.web.HttpRequestHelper;
 import edu.pdx.cs.joy.ParserException;
+import edu.pdx.cs.joy.web.HttpRequestHelper;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;

--- a/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs/joy/airlineweb/IndexDotHtmlIT.java
+++ b/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs/joy/airlineweb/IndexDotHtmlIT.java
@@ -1,6 +1,7 @@
 package edu.pdx.cs.joy.airlineweb;
 
 import edu.pdx.cs.joy.web.HttpRequestHelper;
+import edu.pdx.cs.joy.web.HttpRequestHelper.Response;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -16,17 +17,17 @@ class IndexDotHtmlIT {
 
   @Test
   void indexDotHtmlExists() throws IOException {
-    HttpRequestHelper.Response indexDotHtml = fetchIndexDotHtml();
+    Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getHttpStatusCode(), equalTo(200));
   }
 
   @Test
   void indexDotHtmlHasReasonableContent() throws IOException {
-    HttpRequestHelper.Response indexDotHtml = fetchIndexDotHtml();
+    Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getContent(), containsString("<form"));
   }
 
-  private HttpRequestHelper.Response fetchIndexDotHtml() throws IOException {
+  private Response fetchIndexDotHtml() throws IOException {
     int port = Integer.parseInt(PORT);
     return new IndexDotHtmlHelper(HOSTNAME, port).getIndexDotHtml();
   }
@@ -39,7 +40,7 @@ class IndexDotHtmlIT {
       this.http = new HttpRequestHelper(String.format( "http://%s:%d/%s/%s", hostName, port, WEB_APP, "index.html" ));
     }
 
-    HttpRequestHelper.Response getIndexDotHtml() throws IOException {
+    Response getIndexDotHtml() throws IOException {
       return http.get(Map.of());
     }
   }

--- a/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs/joy/airlineweb/Project5IT.java
+++ b/projects-parent/originals-parent/airline-web/src/it/java/edu/pdx/cs/joy/airlineweb/Project5IT.java
@@ -1,8 +1,8 @@
 package edu.pdx.cs.joy.airlineweb;
 
-import edu.pdx.cs.joy.web.HttpRequestHelper;
 import edu.pdx.cs.joy.InvokeMainTestCase;
 import edu.pdx.cs.joy.UncaughtExceptionInMain;
+import edu.pdx.cs.joy.web.HttpRequestHelper.RestException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
@@ -54,7 +54,7 @@ class Project5IT extends InvokeMainTestCase {
             fail("Should have thrown a RestException");
 
         } catch (UncaughtExceptionInMain ex) {
-            HttpRequestHelper.RestException cause = (HttpRequestHelper.RestException) ex.getCause();
+            RestException cause = (RestException) ex.getCause();
             assertThat(cause.getHttpStatusCode(), equalTo(HttpURLConnection.HTTP_NOT_FOUND));
         }
     }

--- a/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs/joy/airlineweb/AirlineRestClient.java
+++ b/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs/joy/airlineweb/AirlineRestClient.java
@@ -3,11 +3,13 @@ package edu.pdx.cs.joy.airlineweb;
 import com.google.common.annotations.VisibleForTesting;
 import edu.pdx.cs.joy.ParserException;
 import edu.pdx.cs.joy.web.HttpRequestHelper;
+import edu.pdx.cs.joy.web.HttpRequestHelper.Response;
 
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Map;
 
+import static edu.pdx.cs.joy.web.HttpRequestHelper.*;
 import static java.net.HttpURLConnection.HTTP_OK;
 
 /**
@@ -42,7 +44,7 @@ public class AirlineRestClient
    * Returns all dictionary entries from the server
    */
   public Map<String, String> getAllDictionaryEntries() throws IOException, ParserException {
-    HttpRequestHelper.Response response = http.get(Map.of());
+    Response response = http.get(Map.of());
     throwExceptionIfNotOkayHttpStatus(response);
 
     TextParser parser = new TextParser(new StringReader(response.getContent()));
@@ -53,7 +55,7 @@ public class AirlineRestClient
    * Returns the definition for the given word
    */
   public String getDefinition(String word) throws IOException, ParserException {
-    HttpRequestHelper.Response response = http.get(Map.of(AirlineServlet.WORD_PARAMETER, word));
+    Response response = http.get(Map.of(AirlineServlet.WORD_PARAMETER, word));
     throwExceptionIfNotOkayHttpStatus(response);
     String content = response.getContent();
 
@@ -62,20 +64,20 @@ public class AirlineRestClient
   }
 
   public void addDictionaryEntry(String word, String definition) throws IOException {
-    HttpRequestHelper.Response response = http.post(Map.of(AirlineServlet.WORD_PARAMETER, word, AirlineServlet.DEFINITION_PARAMETER, definition));
+    Response response = http.post(Map.of(AirlineServlet.WORD_PARAMETER, word, AirlineServlet.DEFINITION_PARAMETER, definition));
     throwExceptionIfNotOkayHttpStatus(response);
   }
 
   public void removeAllDictionaryEntries() throws IOException {
-    HttpRequestHelper.Response response = http.delete(Map.of());
+    Response response = http.delete(Map.of());
     throwExceptionIfNotOkayHttpStatus(response);
   }
 
-  private void throwExceptionIfNotOkayHttpStatus(HttpRequestHelper.Response response) {
+  private void throwExceptionIfNotOkayHttpStatus(Response response) {
     int code = response.getHttpStatusCode();
     if (code != HTTP_OK) {
       String message = response.getContent();
-      throw new HttpRequestHelper.RestException(code, message);
+      throw new RestException(code, message);
     }
   }
 

--- a/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs/joy/airlineweb/AirlineServlet.java
+++ b/projects-parent/originals-parent/airline-web/src/main/java/edu/pdx/cs/joy/airlineweb/AirlineServlet.java
@@ -2,9 +2,9 @@ package edu.pdx.cs.joy.airlineweb;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;

--- a/projects-parent/originals-parent/airline-web/src/main/webapp/error.jsp
+++ b/projects-parent/originals-parent/airline-web/src/main/webapp/error.jsp
@@ -1,2 +1,2 @@
 <%@ page contentType="text/plain;charset=UTF-8" language="java" isErrorPage="true" %>
-<%out.println( request.getAttribute("javax.servlet.error.message") );%>
+<%out.println( request.getAttribute("jakarta.servlet.error.message") );%>

--- a/projects-parent/originals-parent/airline-web/src/test/java/edu/pdx/cs/joy/airlineweb/AirlineRestClientTest.java
+++ b/projects-parent/originals-parent/airline-web/src/test/java/edu/pdx/cs/joy/airlineweb/AirlineRestClientTest.java
@@ -1,7 +1,7 @@
 package edu.pdx.cs.joy.airlineweb;
 
-import edu.pdx.cs.joy.web.HttpRequestHelper;
 import edu.pdx.cs.joy.ParserException;
+import edu.pdx.cs.joy.web.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -11,7 +11,8 @@ import java.util.Map;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * A unit test for the REST client that demonstrates using mocks and

--- a/projects-parent/originals-parent/airline-web/src/test/java/edu/pdx/cs/joy/airlineweb/AirlineServletTest.java
+++ b/projects-parent/originals-parent/airline-web/src/test/java/edu/pdx/cs/joy/airlineweb/AirlineServletTest.java
@@ -3,8 +3,8 @@ package edu.pdx.cs.joy.airlineweb;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>apptbook-web</artifactId>
-  <version>2.3.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
 
   <properties>
     <jetty.http.port>8080</jetty.http.port>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -36,9 +36,9 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet-api.version}</version>
     </dependency>
   </dependencies>
   <build>

--- a/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs/joy/apptbookweb/AppointmentBookRestClientIT.java
+++ b/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs/joy/apptbookweb/AppointmentBookRestClientIT.java
@@ -1,7 +1,7 @@
 package edu.pdx.cs.joy.apptbookweb;
 
-import edu.pdx.cs.joy.web.HttpRequestHelper;
 import edu.pdx.cs.joy.ParserException;
+import edu.pdx.cs.joy.web.HttpRequestHelper.RestException;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -57,8 +57,7 @@ class AppointmentBookRestClientIT {
     AppointmentBookRestClient client = newAppointmentBookRestClient();
     String emptyString = "";
 
-    HttpRequestHelper.RestException ex =
-      assertThrows(HttpRequestHelper.RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
+    RestException ex = assertThrows(RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
     assertThat(ex.getHttpStatusCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
     assertThat(ex.getMessage(), containsString(Messages.missingRequiredParameter(AppointmentBookServlet.WORD_PARAMETER)));  }
 

--- a/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs/joy/apptbookweb/IndexDotHtmlIT.java
+++ b/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs/joy/apptbookweb/IndexDotHtmlIT.java
@@ -1,6 +1,7 @@
 package edu.pdx.cs.joy.apptbookweb;
 
 import edu.pdx.cs.joy.web.HttpRequestHelper;
+import edu.pdx.cs.joy.web.HttpRequestHelper.Response;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -16,17 +17,17 @@ class IndexDotHtmlIT {
 
   @Test
   void indexDotHtmlExists() throws IOException {
-    HttpRequestHelper.Response indexDotHtml = fetchIndexDotHtml();
+    Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getHttpStatusCode(), equalTo(200));
   }
 
   @Test
   void indexDotHtmlHasReasonableContent() throws IOException {
-    HttpRequestHelper.Response indexDotHtml = fetchIndexDotHtml();
+    Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getContent(), containsString("<form"));
   }
 
-  private HttpRequestHelper.Response fetchIndexDotHtml() throws IOException {
+  private Response fetchIndexDotHtml() throws IOException {
     int port = Integer.parseInt(PORT);
     return new IndexDotHtmlHelper(HOSTNAME, port).getIndexDotHtml();
   }
@@ -39,7 +40,7 @@ class IndexDotHtmlIT {
       this.http = new HttpRequestHelper(String.format( "http://%s:%d/%s/%s", hostName, port, WEB_APP, "index.html" ));
     }
 
-    HttpRequestHelper.Response getIndexDotHtml() throws IOException {
+    Response getIndexDotHtml() throws IOException {
       return http.get(Map.of());
     }
   }

--- a/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs/joy/apptbookweb/Project4IT.java
+++ b/projects-parent/originals-parent/apptbook-web/src/it/java/edu/pdx/cs/joy/apptbookweb/Project4IT.java
@@ -1,8 +1,8 @@
 package edu.pdx.cs.joy.apptbookweb;
 
-import edu.pdx.cs.joy.web.HttpRequestHelper;
 import edu.pdx.cs.joy.InvokeMainTestCase;
 import edu.pdx.cs.joy.UncaughtExceptionInMain;
+import edu.pdx.cs.joy.web.HttpRequestHelper.RestException;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -54,7 +54,7 @@ class Project4IT extends InvokeMainTestCase {
             fail("Expected a RestException to be thrown");
 
         } catch (UncaughtExceptionInMain ex) {
-            HttpRequestHelper.RestException cause = (HttpRequestHelper.RestException) ex.getCause();
+            RestException cause = (RestException) ex.getCause();
             assertThat(cause.getHttpStatusCode(), equalTo(HttpURLConnection.HTTP_NOT_FOUND));
         }
     }

--- a/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs/joy/apptbookweb/AppointmentBookRestClient.java
+++ b/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs/joy/apptbookweb/AppointmentBookRestClient.java
@@ -3,6 +3,8 @@ package edu.pdx.cs.joy.apptbookweb;
 import com.google.common.annotations.VisibleForTesting;
 import edu.pdx.cs.joy.web.HttpRequestHelper;
 import edu.pdx.cs.joy.ParserException;
+import edu.pdx.cs.joy.web.HttpRequestHelper.Response;
+import edu.pdx.cs.joy.web.HttpRequestHelper.RestException;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -41,7 +43,7 @@ public class AppointmentBookRestClient {
    * Returns all dictionary entries from the server
    */
   public Map<String, String> getAllDictionaryEntries() throws IOException, ParserException {
-    HttpRequestHelper.Response response = http.get(Map.of());
+    Response response = http.get(Map.of());
     throwExceptionIfNotOkayHttpStatus(response);
 
     TextParser parser = new TextParser(new StringReader(response.getContent()));
@@ -52,7 +54,7 @@ public class AppointmentBookRestClient {
    * Returns the definition for the given word
    */
   public String getDefinition(String word) throws IOException, ParserException {
-    HttpRequestHelper.Response response = http.get(Map.of(AppointmentBookServlet.WORD_PARAMETER, word));
+    Response response = http.get(Map.of(AppointmentBookServlet.WORD_PARAMETER, word));
     throwExceptionIfNotOkayHttpStatus(response);
     String content = response.getContent();
 
@@ -61,25 +63,25 @@ public class AppointmentBookRestClient {
   }
 
   public void addDictionaryEntry(String word, String definition) throws IOException {
-    HttpRequestHelper.Response response = postToMyURL(Map.of(AppointmentBookServlet.WORD_PARAMETER, word, AppointmentBookServlet.DEFINITION_PARAMETER, definition));
+    Response response = postToMyURL(Map.of(AppointmentBookServlet.WORD_PARAMETER, word, AppointmentBookServlet.DEFINITION_PARAMETER, definition));
     throwExceptionIfNotOkayHttpStatus(response);
   }
 
   @VisibleForTesting
-  HttpRequestHelper.Response postToMyURL(Map<String, String> dictionaryEntries) throws IOException {
+  Response postToMyURL(Map<String, String> dictionaryEntries) throws IOException {
     return http.post(dictionaryEntries);
   }
 
   public void removeAllDictionaryEntries() throws IOException {
-    HttpRequestHelper.Response response = http.delete(Map.of());
+    Response response = http.delete(Map.of());
     throwExceptionIfNotOkayHttpStatus(response);
   }
 
-  private void throwExceptionIfNotOkayHttpStatus(HttpRequestHelper.Response response) {
+  private void throwExceptionIfNotOkayHttpStatus(Response response) {
     int code = response.getHttpStatusCode();
     if (code != HTTP_OK) {
       String message = response.getContent();
-      throw new HttpRequestHelper.RestException(code, message);
+      throw new RestException(code, message);
     }
   }
 

--- a/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs/joy/apptbookweb/AppointmentBookServlet.java
+++ b/projects-parent/originals-parent/apptbook-web/src/main/java/edu/pdx/cs/joy/apptbookweb/AppointmentBookServlet.java
@@ -2,9 +2,9 @@ package edu.pdx.cs.joy.apptbookweb;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;

--- a/projects-parent/originals-parent/apptbook-web/src/main/webapp/error.jsp
+++ b/projects-parent/originals-parent/apptbook-web/src/main/webapp/error.jsp
@@ -1,2 +1,2 @@
 <%@ page contentType="text/plain;charset=UTF-8" language="java" isErrorPage="true" %>
-<%out.println( request.getAttribute("javax.servlet.error.message") );%>
+<%out.println( request.getAttribute("jakarta.servlet.error.message") );%>

--- a/projects-parent/originals-parent/apptbook-web/src/test/java/edu/pdx/cs/joy/apptbookweb/AppointmentBookRestClientTest.java
+++ b/projects-parent/originals-parent/apptbook-web/src/test/java/edu/pdx/cs/joy/apptbookweb/AppointmentBookRestClientTest.java
@@ -1,7 +1,7 @@
 package edu.pdx.cs.joy.apptbookweb;
 
-import edu.pdx.cs.joy.web.HttpRequestHelper;
 import edu.pdx.cs.joy.ParserException;
+import edu.pdx.cs.joy.web.HttpRequestHelper;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;

--- a/projects-parent/originals-parent/apptbook-web/src/test/java/edu/pdx/cs/joy/apptbookweb/AppointmentBookServletTest.java
+++ b/projects-parent/originals-parent/apptbook-web/src/test/java/edu/pdx/cs/joy/apptbookweb/AppointmentBookServletTest.java
@@ -3,9 +3,9 @@ package edu.pdx.cs.joy.apptbookweb;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -41,13 +41,6 @@
       <artifactId>jakarta.servlet-api</artifactId>
       <version>${jakarta.servlet-api.version}</version>
     </dependency>
-    <dependency>
-      <groupId>jakarta.platform</groupId>
-      <artifactId>jakarta.jakartaee-bom</artifactId>
-      <version>10.0.0</version>
-      <scope>import</scope>
-      <type>pom</type>
-    </dependency>
   </dependencies>
   <build>
     <finalName>phonebill</finalName>  <!-- Need finalName to make integration tests work -->

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -8,7 +8,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>phonebill-web</artifactId>
-  <version>2.3.0-SNAPSHOT</version>
+  <version>3.0.0-SNAPSHOT</version>
 
   <properties>
     <jetty.http.port>8080</jetty.http.port>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -37,9 +37,16 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.1.0</version>
+    </dependency>
+    <dependency>
+      <groupId>jakarta.platform</groupId>
+      <artifactId>jakarta.jakartaee-bom</artifactId>
+      <version>10.0.0</version>
+      <scope>import</scope>
+      <type>pom</type>
     </dependency>
   </dependencies>
   <build>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>
-      <version>6.1.0</version>
+      <version>${jakarta.servlet-api.version}</version>
     </dependency>
     <dependency>
       <groupId>jakarta.platform</groupId>

--- a/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs/joy/phonebillweb/IndexDotHtmlIT.java
+++ b/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs/joy/phonebillweb/IndexDotHtmlIT.java
@@ -1,6 +1,7 @@
 package edu.pdx.cs.joy.phonebillweb;
 
 import edu.pdx.cs.joy.web.HttpRequestHelper;
+import edu.pdx.cs.joy.web.HttpRequestHelper.Response;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -16,17 +17,17 @@ class IndexDotHtmlIT {
 
   @Test
   void indexDotHtmlExists() throws IOException {
-    HttpRequestHelper.Response indexDotHtml = fetchIndexDotHtml();
+    Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getHttpStatusCode(), equalTo(200));
   }
 
   @Test
   void indexDotHtmlHasReasonableContent() throws IOException {
-    HttpRequestHelper.Response indexDotHtml = fetchIndexDotHtml();
+    Response indexDotHtml = fetchIndexDotHtml();
     assertThat(indexDotHtml.getContent(), containsString("<form"));
   }
 
-  private HttpRequestHelper.Response fetchIndexDotHtml() throws IOException {
+  private Response fetchIndexDotHtml() throws IOException {
     int port = Integer.parseInt(PORT);
     return new IndexDotHtmlHelper(HOSTNAME, port).getIndexDotHtml();
   }
@@ -39,7 +40,7 @@ class IndexDotHtmlIT {
       this.http = new HttpRequestHelper(String.format( "http://%s:%d/%s/%s", hostName, port, WEB_APP, "index.html" ));
     }
 
-    HttpRequestHelper.Response getIndexDotHtml() throws IOException {
+    Response getIndexDotHtml() throws IOException {
       return http.get(Map.of());
     }
   }

--- a/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs/joy/phonebillweb/PhoneBillRestClientIT.java
+++ b/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs/joy/phonebillweb/PhoneBillRestClientIT.java
@@ -1,7 +1,7 @@
 package edu.pdx.cs.joy.phonebillweb;
 
-import edu.pdx.cs.joy.web.HttpRequestHelper;
 import edu.pdx.cs.joy.ParserException;
+import edu.pdx.cs.joy.web.HttpRequestHelper.RestException;
 import org.junit.jupiter.api.MethodOrderer.MethodName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -57,8 +57,7 @@ class PhoneBillRestClientIT {
     PhoneBillRestClient client = newPhoneBillRestClient();
     String emptyString = "";
 
-    HttpRequestHelper.RestException ex =
-      assertThrows(HttpRequestHelper.RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
+    RestException ex = assertThrows(RestException.class, () -> client.addDictionaryEntry(emptyString, emptyString));
     assertThat(ex.getHttpStatusCode(), equalTo(HttpURLConnection.HTTP_PRECON_FAILED));
     assertThat(ex.getMessage(), containsString(Messages.missingRequiredParameter(PhoneBillServlet.WORD_PARAMETER)));
   }

--- a/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs/joy/phonebillweb/Project4IT.java
+++ b/projects-parent/originals-parent/phonebill-web/src/it/java/edu/pdx/cs/joy/phonebillweb/Project4IT.java
@@ -1,8 +1,8 @@
 package edu.pdx.cs.joy.phonebillweb;
 
-import edu.pdx.cs.joy.web.HttpRequestHelper;
 import edu.pdx.cs.joy.InvokeMainTestCase;
 import edu.pdx.cs.joy.UncaughtExceptionInMain;
+import edu.pdx.cs.joy.web.HttpRequestHelper.RestException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
@@ -53,7 +53,7 @@ class Project4IT extends InvokeMainTestCase {
             fail("Expected a RestException to be thrown");
 
         } catch (UncaughtExceptionInMain ex) {
-            HttpRequestHelper.RestException cause = (HttpRequestHelper.RestException) ex.getCause();
+            RestException cause = (RestException) ex.getCause();
             assertThat(cause.getHttpStatusCode(), equalTo(HttpURLConnection.HTTP_NOT_FOUND));
         }
     }

--- a/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs/joy/phonebillweb/PhoneBillRestClient.java
+++ b/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs/joy/phonebillweb/PhoneBillRestClient.java
@@ -1,8 +1,10 @@
 package edu.pdx.cs.joy.phonebillweb;
 
 import com.google.common.annotations.VisibleForTesting;
-import edu.pdx.cs.joy.web.HttpRequestHelper;
 import edu.pdx.cs.joy.ParserException;
+import edu.pdx.cs.joy.web.HttpRequestHelper;
+import edu.pdx.cs.joy.web.HttpRequestHelper.Response;
+import edu.pdx.cs.joy.web.HttpRequestHelper.RestException;
 
 import java.io.IOException;
 import java.io.StringReader;
@@ -42,7 +44,7 @@ public class PhoneBillRestClient {
    * Returns all dictionary entries from the server
    */
   public Map<String, String> getAllDictionaryEntries() throws IOException, ParserException {
-    HttpRequestHelper.Response response = http.get(Map.of());
+    Response response = http.get(Map.of());
     throwExceptionIfNotOkayHttpStatus(response);
 
     TextParser parser = new TextParser(new StringReader(response.getContent()));
@@ -53,7 +55,7 @@ public class PhoneBillRestClient {
    * Returns the definition for the given word
    */
   public String getDefinition(String word) throws IOException, ParserException {
-    HttpRequestHelper.Response response = http.get(Map.of(PhoneBillServlet.WORD_PARAMETER, word));
+    Response response = http.get(Map.of(PhoneBillServlet.WORD_PARAMETER, word));
     throwExceptionIfNotOkayHttpStatus(response);
     String content = response.getContent();
 
@@ -62,20 +64,20 @@ public class PhoneBillRestClient {
   }
 
     public void addDictionaryEntry(String word, String definition) throws IOException {
-      HttpRequestHelper.Response response = http.post(Map.of(PhoneBillServlet.WORD_PARAMETER, word, PhoneBillServlet.DEFINITION_PARAMETER, definition));
+      Response response = http.post(Map.of(PhoneBillServlet.WORD_PARAMETER, word, PhoneBillServlet.DEFINITION_PARAMETER, definition));
       throwExceptionIfNotOkayHttpStatus(response);
     }
 
   public void removeAllDictionaryEntries() throws IOException {
-      HttpRequestHelper.Response response = http.delete(Map.of());
+      Response response = http.delete(Map.of());
       throwExceptionIfNotOkayHttpStatus(response);
     }
 
-    private void throwExceptionIfNotOkayHttpStatus(HttpRequestHelper.Response response) {
+    private void throwExceptionIfNotOkayHttpStatus(Response response) {
       int code = response.getHttpStatusCode();
       if (code != HTTP_OK) {
         String message = response.getContent();
-        throw new HttpRequestHelper.RestException(code, message);
+        throw new RestException(code, message);
       }
     }
 

--- a/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs/joy/phonebillweb/PhoneBillServlet.java
+++ b/projects-parent/originals-parent/phonebill-web/src/main/java/edu/pdx/cs/joy/phonebillweb/PhoneBillServlet.java
@@ -2,9 +2,9 @@ package edu.pdx.cs.joy.phonebillweb;
 
 import com.google.common.annotations.VisibleForTesting;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.HashMap;

--- a/projects-parent/originals-parent/phonebill-web/src/main/webapp/error.jsp
+++ b/projects-parent/originals-parent/phonebill-web/src/main/webapp/error.jsp
@@ -1,2 +1,2 @@
 <%@ page contentType="text/plain;charset=UTF-8" language="java" isErrorPage="true" %>
-<%out.println( request.getAttribute("javax.servlet.error.message") );%>
+<%out.println( request.getAttribute("jakarta.servlet.error.message") );%>

--- a/projects-parent/originals-parent/phonebill-web/src/test/java/edu/pdx/cs/joy/phonebillweb/PhoneBillRestClientTest.java
+++ b/projects-parent/originals-parent/phonebill-web/src/test/java/edu/pdx/cs/joy/phonebillweb/PhoneBillRestClientTest.java
@@ -1,7 +1,8 @@
 package edu.pdx.cs.joy.phonebillweb;
 
-import edu.pdx.cs.joy.web.HttpRequestHelper;
 import edu.pdx.cs.joy.ParserException;
+import edu.pdx.cs.joy.web.HttpRequestHelper;
+import edu.pdx.cs.joy.web.HttpRequestHelper.Response;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -28,10 +29,10 @@ public class PhoneBillRestClientTest {
     assertThat(client.getAllDictionaryEntries(), equalTo(dictionary));
   }
 
-  private HttpRequestHelper.Response dictionaryAsText(Map<String, String> dictionary) {
+  private Response dictionaryAsText(Map<String, String> dictionary) {
     StringWriter writer = new StringWriter();
     new TextDumper(writer).dump(dictionary);
 
-    return new HttpRequestHelper.Response(writer.toString());
+    return new Response(writer.toString());
   }
 }

--- a/projects-parent/originals-parent/phonebill-web/src/test/java/edu/pdx/cs/joy/phonebillweb/PhoneBillServletTest.java
+++ b/projects-parent/originals-parent/phonebill-web/src/test/java/edu/pdx/cs/joy/phonebillweb/PhoneBillServletTest.java
@@ -3,9 +3,9 @@ package edu.pdx.cs.joy.phonebillweb;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -12,7 +12,7 @@
   <version>1.3.0-SNAPSHOT</version>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <properties>
-    <resteasy.version>6.2.8.Final</resteasy.version>
+    <resteasy.version>6.2.11.Final</resteasy.version>
     <jetty.http.port>8080</jetty.http.port>
   </properties>
   <build>
@@ -100,14 +100,16 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>4.0.1</version>
+      <groupId>jakarta.platform</groupId>
+      <artifactId>jakarta.jakartaee-bom</artifactId>
+      <version>10.0.0</version>
+      <scope>import</scope>
+      <type>pom</type>
     </dependency>
     <dependency>
-      <groupId>commons-fileupload</groupId>
-      <artifactId>commons-fileupload</artifactId>
-      <version>1.5</version>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
+      <version>2.0.0-M2</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -126,13 +128,20 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
-      <artifactId>resteasy-jaxb-provider</artifactId>
+      <artifactId>resteasy-bom</artifactId>
       <version>${resteasy.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
     </dependency>
     <dependency>
-      <groupId>org.jboss.resteasy</groupId>
+      <groupId>jakarta.ws.rs</groupId>
+      <artifactId>jakarta.ws.rs-api</artifactId>
+      <version>4.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>dev.resteasy.guice</groupId>
       <artifactId>resteasy-guice</artifactId>
-      <version>4.7.9.Final</version>
+      <version>1.0.0.Alpha1</version>
     </dependency>
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -100,11 +100,9 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>jakarta.platform</groupId>
-      <artifactId>jakarta.jakartaee-bom</artifactId>
-      <version>10.0.0</version>
-      <scope>import</scope>
-      <type>pom</type>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>${jakarta.servlet-api.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -9,7 +9,7 @@
   <artifactId>web</artifactId>
   <packaging>war</packaging>
   <name>Web Application examples</name>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <properties>
     <resteasy.version>6.2.11.Final</resteasy.version>

--- a/web/src/main/java/edu/pdx/cs/joy/di/RestLoggingFilter.java
+++ b/web/src/main/java/edu/pdx/cs/joy/di/RestLoggingFilter.java
@@ -2,9 +2,9 @@ package edu.pdx.cs.joy.di;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
 
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.logging.Logger;
 
@@ -24,7 +24,8 @@ public class RestLoggingFilter implements Filter
       this.cards = cards;        
     }
 
-    public void init( FilterConfig config ) throws ServletException
+    @Override
+    public void init(FilterConfig config ) throws ServletException
     {
       // Initialize some credit cards for testing purposes.  This probably isn't the best place to do this. 
       for (int i = 1; i <= 10; i++) {
@@ -33,7 +34,8 @@ public class RestLoggingFilter implements Filter
       }
     }
 
-    public void doFilter( ServletRequest request, ServletResponse response, FilterChain chain )
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain )
         throws IOException, ServletException
     {
         long begin = System.currentTimeMillis();
@@ -56,6 +58,7 @@ public class RestLoggingFilter implements Filter
 
     }
 
+    @Override
     public void destroy()
     {
 

--- a/web/src/main/java/edu/pdx/cs/joy/di/RestfulCreditCardService.java
+++ b/web/src/main/java/edu/pdx/cs/joy/di/RestfulCreditCardService.java
@@ -2,10 +2,8 @@ package edu.pdx.cs.joy.di;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
+import jakarta.ws.rs.*;
 
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.Produces;
 import java.util.Map;
 
 /**

--- a/web/src/main/java/edu/pdx/cs/joy/servlets/FamilyTreeServlet.java
+++ b/web/src/main/java/edu/pdx/cs/joy/servlets/FamilyTreeServlet.java
@@ -3,16 +3,15 @@ package edu.pdx.cs.joy.servlets;
 import edu.pdx.cs.joy.family.FamilyTree;
 import edu.pdx.cs.joy.family.Person;
 import edu.pdx.cs.joy.family.XmlDumper;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.ServletConfig;
-import javax.servlet.ServletException;
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.util.Date;
 import java.util.Collection;
+import java.util.Date;
 
 /**
  * A servlet that provides access to a {@link FamilyTree} via REST
@@ -24,15 +23,18 @@ public class FamilyTreeServlet extends HttpServlet {
 
   private int nextPersonId = 1;
 
-  public void init(ServletConfig servletConfig) throws ServletException {
+  @Override
+  public void init(ServletConfig servletConfig) {
     tree = new FamilyTree();
   }
 
-  protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+  @Override
+  protected void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     createPerson(request, response);
   }
 
-  protected void doGet(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
+  @Override
+  protected void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     String uri = request.getRequestURI();
     String lastPart = uri.substring(uri.lastIndexOf('/') + 1, uri.length());
 

--- a/web/src/main/java/edu/pdx/cs/joy/servlets/FileUploadServlet.java
+++ b/web/src/main/java/edu/pdx/cs/joy/servlets/FileUploadServlet.java
@@ -1,21 +1,19 @@
 package edu.pdx.cs.joy.servlets;
 
-import org.apache.commons.fileupload.servlet.ServletFileUpload;
-import org.apache.commons.fileupload.FileItemFactory;
-import org.apache.commons.fileupload.FileUploadException;
-import org.apache.commons.fileupload.FileItem;
-import org.apache.commons.fileupload.disk.DiskFileItemFactory;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.apache.commons.fileupload2.core.DiskFileItem;
+import org.apache.commons.fileupload2.core.DiskFileItemFactory;
+import org.apache.commons.fileupload2.core.FileUploadException;
+import org.apache.commons.fileupload2.jakarta.servlet6.JakartaServletFileUpload;
 
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.ServletException;
-import java.io.IOException;
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.util.List;
-import java.util.Iterator;
 
 /**
  * A servlet that demonstrates how to upload a file to a web server.  It uses the Apache Commons
@@ -26,16 +24,17 @@ import java.util.Iterator;
  */
 public class FileUploadServlet extends HttpServlet {
 
+  @Override
   protected void doPost(HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
     response.setContentType("text/html");
     PrintWriter pw = response.getWriter();
     pw.println("<html>");
     pw.println("<body>");
 
-    if (ServletFileUpload.isMultipartContent(request)) {
-      FileItemFactory factory = new DiskFileItemFactory();
-      ServletFileUpload upload = new ServletFileUpload(factory);
-      List items;
+    if (JakartaServletFileUpload.isMultipartContent(request)) {
+      DiskFileItemFactory factory = new DiskFileItemFactory.Builder().get();
+      JakartaServletFileUpload<DiskFileItem, DiskFileItemFactory> upload = new JakartaServletFileUpload<>(factory);
+      List<DiskFileItem> items;
       try {
         items = upload.parseRequest(request);
 
@@ -43,17 +42,13 @@ public class FileUploadServlet extends HttpServlet {
         throw new ServletException("Could not upload file", ex);
       }
 
-      for (Iterator iter = items.iterator(); iter.hasNext(); ) {
-        FileItem item = (FileItem) iter.next();
-        if (item.isFormField()) {
-          // Non-file field in the form
-
-        } else {
+      for (DiskFileItem item : items) {
+        if (!item.isFormField()) {
           String fileName = item.getName();
           String contentType = item.getContentType();
           pw.println("<h1>You uploaded " + fileName + "</h1>");
           pw.println("<h2>Content type is " + contentType + "</h2>");
-          
+
           if (contentType.equals("text/plain")) {
             pw.println("<pre>");
 
@@ -65,6 +60,7 @@ public class FileUploadServlet extends HttpServlet {
             pw.println("</pre>");
           }
         }
+
       }
 
     } else {

--- a/web/src/main/java/edu/pdx/cs/joy/servlets/LastVisitServlet.java
+++ b/web/src/main/java/edu/pdx/cs/joy/servlets/LastVisitServlet.java
@@ -1,9 +1,9 @@
 package edu.pdx.cs.joy.servlets;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.time.LocalDateTime;

--- a/web/src/main/java/edu/pdx/cs/joy/servlets/MovieDatabaseServlet.java
+++ b/web/src/main/java/edu/pdx/cs/joy/servlets/MovieDatabaseServlet.java
@@ -4,10 +4,10 @@ import edu.pdx.cs.joy.rmi.Movie;
 import edu.pdx.cs.joy.rmi.MovieDatabase;
 import edu.pdx.cs.joy.rmi.MovieDatabaseImpl;
 
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -16,8 +16,8 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 
-import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static jakarta.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
+import static jakarta.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 
 /**
  * A servlet that provides REST access to a movie database

--- a/web/src/main/java/edu/pdx/cs/joy/servlets/ServletInfoServlet.java
+++ b/web/src/main/java/edu/pdx/cs/joy/servlets/ServletInfoServlet.java
@@ -2,8 +2,8 @@ package edu.pdx.cs.joy.servlets;
 
 import java.io.*;
 import java.util.*;
-import javax.servlet.*;
-import javax.servlet.http.*;
+import jakarta.servlet.*;
+import jakarta.servlet.http.*;
 
 /**
  * A servlet that returns all sorts of information available from the

--- a/web/src/main/java/edu/pdx/cs/joy/servlets/SessionServlet.java
+++ b/web/src/main/java/edu/pdx/cs/joy/servlets/SessionServlet.java
@@ -1,7 +1,7 @@
 package edu.pdx.cs.joy.servlets;
 
-import javax.servlet.http.*;
-import javax.servlet.ServletException;
+import jakarta.servlet.http.*;
+import jakarta.servlet.ServletException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Date;

--- a/web/src/main/webapp/WEB-INF/web.xml
+++ b/web/src/main/webapp/WEB-INF/web.xml
@@ -20,7 +20,7 @@
   </filter-mapping>
   <listener>
     <listener-class>
-      org.jboss.resteasy.plugins.guice.GuiceResteasyBootstrapServletContextListener
+      dev.resteasy.guice.GuiceResteasyBootstrapServletContextListener
     </listener-class>
   </listener>
   <servlet>


### PR DESCRIPTION
Address #404 by upgrading to Jetty 11.  This also requires that servlet code now use the `jakarta.servlet` APIs instead of the `javax.servlet` APIs.