### PR TITLE
Warn of NBSP in AboutDates koan

### DIFF
--- a/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
@@ -9,7 +9,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>java-koans-archetype</artifactId>
-  <version>2.2.2</version>
+  <version>2.2.3</version>
   <packaging>maven-archetype</packaging>
 
   <name>java-koans-archetype</name>

--- a/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/src/intermediate/AboutDates.java
+++ b/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/src/intermediate/AboutDates.java
@@ -18,7 +18,7 @@ import static com.sandwich.util.Assert.assertEquals;
 
 public class AboutDates {
 
-    private LocalDateTime date = LocalDateTime.ofInstant(Instant.ofEpochMilli(100010001000L), ZoneId.systemDefault());
+    private LocalDateTime date = LocalDateTime.ofInstant(Instant.ofEpochMilli(100010001000L), ZoneId.of("-07:00"));
 
     @Koan
     public void dateToString() {
@@ -45,6 +45,7 @@ public class AboutDates {
 
     @Koan
     public void usingDateTimeFormatterToFormatDateShort() {
+        // Careful, formatted dates may contain non-breaking spaces!
         String formattedDate = DateTimeFormatter.ofLocalizedDateTime(FormatStyle.SHORT).format(date);
         assertEquals(formattedDate, __);
     }


### PR DESCRIPTION
Propagate changes to AboutDates koan to warn of non-breaking spaces in formatted dates/times.