### PR TITLE
Extract GitHub id from HTTPS URL

### DIFF
--- a/grader/src/main/java/edu/pdx/cs/joy/grader/GitHubUserNameFinder.java
+++ b/grader/src/main/java/edu/pdx/cs/joy/grader/GitHubUserNameFinder.java
@@ -20,14 +20,14 @@ public class GitHubUserNameFinder implements GitConfigParser.Callback {
   }
 
   private void extractGitHubUserNameFrom(String gitUrl) {
-    Matcher gitHubUrl = Pattern.compile("git@github.com:(.*)/.*\\.git").matcher(gitUrl);
-    if (gitHubUrl.matches()) {
-      this.gitHubUserName = gitHubUrl.group(1);
+    Matcher gitHubMatcher = Pattern.compile("git@github.com:(.*)/.*\\.git").matcher(gitUrl);
+    if (gitHubMatcher.matches()) {
+      this.gitHubUserName = gitHubMatcher.group(1);
 
     } else {
-      Matcher httpsUrl = Pattern.compile("https://github.com/(.*)/.*\\.git").matcher(gitUrl);
-      if (httpsUrl.matches()) {
-        this.gitHubUserName = httpsUrl.group(1);
+      Matcher httpsMatcher = Pattern.compile("https://github.com/(.*)/.*\\.git").matcher(gitUrl);
+      if (httpsMatcher.matches()) {
+        this.gitHubUserName = httpsMatcher.group(1);
       }
     }
   }

--- a/grader/src/main/java/edu/pdx/cs/joy/grader/GitHubUserNameFinder.java
+++ b/grader/src/main/java/edu/pdx/cs/joy/grader/GitHubUserNameFinder.java
@@ -20,10 +20,15 @@ public class GitHubUserNameFinder implements GitConfigParser.Callback {
   }
 
   private void extractGitHubUserNameFrom(String gitUrl) {
-    Pattern pattern = Pattern.compile("git@github.com:(.*)/.*\\.git");
-    Matcher matcher = pattern.matcher(gitUrl);
-    if (matcher.matches()) {
-      this.gitHubUserName = matcher.group(1);
+    Matcher gitHubUrl = Pattern.compile("git@github.com:(.*)/.*\\.git").matcher(gitUrl);
+    if (gitHubUrl.matches()) {
+      this.gitHubUserName = gitHubUrl.group(1);
+
+    } else {
+      Matcher httpsUrl = Pattern.compile("https://github.com/(.*)/.*\\.git").matcher(gitUrl);
+      if (httpsUrl.matches()) {
+        this.gitHubUserName = httpsUrl.group(1);
+      }
     }
   }
 

--- a/grader/src/test/java/edu/pdx/cs/joy/grader/GitHubUserNameFinderTest.java
+++ b/grader/src/test/java/edu/pdx/cs/joy/grader/GitHubUserNameFinderTest.java
@@ -8,10 +8,19 @@ import static org.hamcrest.Matchers.equalTo;
 public class GitHubUserNameFinderTest {
 
   @Test
-  void findGitHubUserName() {
+  void findGitHubUserNameWithGitHubUrl() {
     GitHubUserNameFinder finder = new GitHubUserNameFinder();
     finder.startRemoteSection("origin");
     finder.property("url", "git@github.com:JoyOfCodingPDX/JoyOfCoding.git");
+
+    assertThat(finder.getGitHubUserName(), equalTo("JoyOfCodingPDX"));
+  }
+
+  @Test
+  void findGitHubUserNameWithHttpsUrl() {
+    GitHubUserNameFinder finder = new GitHubUserNameFinder();
+    finder.startRemoteSection("origin");
+    finder.property("url", "https://github.com/JoyOfCodingPDX/JoyOfCoding.git");
 
     assertThat(finder.getGitHubUserName(), equalTo("JoyOfCodingPDX"));
   }

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
       <jacoco.min.instruction.covered.ratio>0.75</jacoco.min.instruction.covered.ratio>
       <jacoco.max.missed.classes>0</jacoco.max.missed.classes>
 
-      <grader.version>1.3.3</grader.version>
+      <grader.version>1.3.4</grader.version>
     </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Resolve #508 by parsing a student's GitHub id from an HTTPS URL in the Git Config file.