### PR TITLE
Increment micro version so that artifacts can be published.

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -3,23 +3,23 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>examples</artifactId>
   <name>examples</name>
-  <version>1.3.3</version>
+  <version>1.3.4</version>
   <url>https://www.cs.pdx.edu/~whitlock</url>
   <dependencies>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>family</artifactId>
-      <version>1.1.4</version>
+      <version>1.1.5</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.sun.mail</groupId>
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/family/pom.xml
+++ b/family/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>family</artifactId>
   <packaging>jar</packaging>
-  <version>1.1.4</version>
+  <version>1.1.5</version>
   <name>Family Tree Application</name>
   <description>An Family Tree application for The Joy of Coding</description>
   <url>https://www.cs.pdx.edu/~whitlock</url>
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
   </dependencies>
   <build>

--- a/grader/pom.xml
+++ b/grader/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>grader</artifactId>
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>com.opencsv</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy</groupId>
-  <version>1.2.2</version>
+  <version>1.2.3</version>
   <artifactId>joy</artifactId>
   <packaging>pom</packaging>
   <name>Java Example Code</name>

--- a/projects-parent/archetypes-parent/airline-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/pom.xml
@@ -5,10 +5,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <artifactId>airline-archetype</artifactId>
-  <version>2.2.2</version>
+  <version>2.2.3</version>
   <packaging>maven-archetype</packaging>
 
   <name>airline-archetype</name>

--- a/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/airline-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <artifactId>airline-web-archetype</artifactId>
-  <version>3.0.2</version>
+  <version>3.0.3</version>
   <packaging>maven-archetype</packaging>
 
   <name>airline-web-archetype</name>

--- a/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/airline-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -21,17 +21,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.3.3</version>
+      <version>1.3.4</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/apptbook-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <artifactId>apptbook-archetype</artifactId>
-  <version>2.2.2</version>
+  <version>2.2.3</version>
   <packaging>maven-archetype</packaging>
 
   <name>apptbook-archetype</name>

--- a/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <artifactId>apptbook-web-archetype</artifactId>
-  <version>3.0.2</version>
+  <version>3.0.3</version>
   <packaging>maven-archetype</packaging>
 
   <name>apptbook-web-archetype</name>

--- a/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/apptbook-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -21,17 +21,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.3.3</version>
+      <version>1.3.4</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/java-koans-archetype/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>java-koans-archetype</artifactId>
-  <version>2.2.3</version>
+  <version>2.2.4</version>
   <packaging>maven-archetype</packaging>
 
   <name>java-koans-archetype</name>

--- a/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/java-koans-archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
   <artifactId>${artifactId}</artifactId>
   <groupId>${groupId}</groupId>

--- a/projects-parent/archetypes-parent/kata-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/kata-archetype/pom.xml
@@ -5,10 +5,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <artifactId>kata-archetype</artifactId>
-  <version>2.2.2</version>
+  <version>2.2.3</version>
   <packaging>maven-archetype</packaging>
 
   <name>kata-archetype</name>

--- a/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/kata-archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/phonebill-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/pom.xml
@@ -3,11 +3,11 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>phonebill-archetype</artifactId>
-  <version>2.2.2</version>
+  <version>2.2.3</version>
   <packaging>maven-archetype</packaging>
 
   <name>phonebill-archetype</name>

--- a/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/pom.xml
@@ -4,10 +4,10 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <artifactId>phonebill-web-archetype</artifactId>
-  <version>3.0.2</version>
+  <version>3.0.3</version>
   <packaging>maven-archetype</packaging>
 
   <name>phonebill-web-archetype</name>

--- a/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/phonebill-web-archetype/src/main/resources/archetype-resources/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>${groupId}</groupId>
@@ -22,17 +22,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.3.3</version>
+      <version>1.3.4</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/archetypes-parent/pom.xml
+++ b/projects-parent/archetypes-parent/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.github.davidwhitlock.joy</groupId>
         <artifactId>projects-parent</artifactId>
-        <version>2.2.2</version>
+        <version>2.2.3</version>
     </parent>
 
     <artifactId>archetypes-parent</artifactId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
 
     <packaging>pom</packaging>
 

--- a/projects-parent/archetypes-parent/student-archetype/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/pom.xml
@@ -5,11 +5,11 @@
   <parent>
     <artifactId>archetypes-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
 
   <artifactId>student-archetype</artifactId>
-  <version>2.3.3</version>
+  <version>2.3.4</version>
   <packaging>maven-archetype</packaging>
 
   <name>Archetype for Student project</name>

--- a/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/projects-parent/archetypes-parent/student-archetype/src/main/resources/archetype-resources/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
@@ -102,12 +102,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId> <!-- For the Human class -->
-      <version>1.3.3</version>
+      <version>1.3.4</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/airline-web/pom.xml
+++ b/projects-parent/originals-parent/airline-web/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>airline-web</artifactId>
-  <version>3.0.2</version>
+  <version>3.0.3</version>
 
   <properties>
     <jetty.http.port>8080</jetty.http.port>
@@ -21,17 +21,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.3.3</version>
+      <version>1.3.4</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/airline/pom.xml
+++ b/projects-parent/originals-parent/airline/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>airline</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.2</version>
+  <version>2.2.3</version>
   <name>Airline Project</name>
   <description>An Airline application for The Joy of Coding at Portland State University</description>
   <inceptionYear>2000</inceptionYear>
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/apptbook-web/pom.xml
+++ b/projects-parent/originals-parent/apptbook-web/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>apptbook-web</artifactId>
-  <version>3.0.2</version>
+  <version>3.0.3</version>
 
   <properties>
     <jetty.http.port>8080</jetty.http.port>
@@ -21,17 +21,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.3.3</version>
+      <version>1.3.4</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/apptbook/pom.xml
+++ b/projects-parent/originals-parent/apptbook/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>apptbook</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.2</version>
+  <version>2.2.3</version>
   <name>Appointment Book Project</name>
   <description>An Appointment Book application for The Joy of Coding at Portland State University</description>
   <inceptionYear>2000</inceptionYear>
@@ -32,12 +32,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/kata/pom.xml
+++ b/projects-parent/originals-parent/kata/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>kata</artifactId>
-  <version>2.2.2</version>
+  <version>2.2.3</version>
   <packaging>jar</packaging>
 
   <name>Kata Project</name>
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/phonebill-web/pom.xml
+++ b/projects-parent/originals-parent/phonebill-web/pom.xml
@@ -3,12 +3,12 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>phonebill-web</artifactId>
-  <version>3.0.2</version>
+  <version>3.0.3</version>
 
   <properties>
     <jetty.http.port>8080</jetty.http.port>
@@ -22,17 +22,17 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.3.3</version>
+      <version>1.3.4</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/phonebill/pom.xml
+++ b/projects-parent/originals-parent/phonebill/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>phonebill</artifactId>
   <packaging>jar</packaging>
-  <version>2.2.2</version>
+  <version>2.2.3</version>
   <name>Phone Bill Project</name>
   <description>A Phone Bill application for The Joy of Coding at Portland State University</description>
   <inceptionYear>2000</inceptionYear>
@@ -38,12 +38,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId>
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/originals-parent/pom.xml
+++ b/projects-parent/originals-parent/pom.xml
@@ -5,11 +5,11 @@
     <parent>
         <groupId>io.github.davidwhitlock.joy</groupId>
         <artifactId>projects-parent</artifactId>
-        <version>2.2.2</version>
+        <version>2.2.3</version>
     </parent>
 
     <artifactId>originals-parent</artifactId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
 
     <packaging>pom</packaging>
 

--- a/projects-parent/originals-parent/student/pom.xml
+++ b/projects-parent/originals-parent/student/pom.xml
@@ -4,11 +4,11 @@
   <parent>
     <artifactId>originals-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <groupId>io.github.davidwhitlock.joy.original</groupId>
   <artifactId>student</artifactId>
-  <version>2.3.3</version>
+  <version>2.3.4</version>
   <packaging>jar</packaging>
 
   <name>Student Project</name>
@@ -88,12 +88,12 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId> <!-- For the Human class -->
-      <version>1.3.3</version>
+      <version>1.3.4</version>
     </dependency>
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>projects</artifactId> <!-- For the InvokeMainTest class -->
-      <version>3.0.2</version>
+      <version>3.0.3</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/projects-parent/pom.xml
+++ b/projects-parent/pom.xml
@@ -7,11 +7,11 @@
     <parent>
         <groupId>io.github.davidwhitlock.joy</groupId>
         <artifactId>joy</artifactId>
-        <version>1.2.2</version>
+        <version>1.2.3</version>
     </parent>
 
     <artifactId>projects-parent</artifactId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
 
     <packaging>pom</packaging>
 

--- a/projects-parent/projects/pom.xml
+++ b/projects-parent/projects/pom.xml
@@ -2,13 +2,13 @@
   <parent>
     <artifactId>projects-parent</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>2.2.2</version>
+    <version>2.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>projects</artifactId>
   <name>Project APIs</name>
   <description>Classes needed for the Projects in The Joy of Coding</description>
-  <version>3.0.2</version>
+  <version>3.0.3</version>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <build>
     <plugins>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -3,13 +3,13 @@
   <parent>
     <artifactId>joy</artifactId>
     <groupId>io.github.davidwhitlock.joy</groupId>
-    <version>1.2.2</version>
+    <version>1.2.3</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>web</artifactId>
   <packaging>war</packaging>
   <name>Web Application examples</name>
-  <version>2.0.2</version>
+  <version>2.0.3</version>
   <url>http://www.cs.pdx.edu/~whitlock</url>
   <properties>
     <resteasy.version>6.2.11.Final</resteasy.version>
@@ -117,7 +117,7 @@
     <dependency>
       <groupId>io.github.davidwhitlock.joy</groupId>
       <artifactId>examples</artifactId>
-      <version>1.3.3</version>
+      <version>1.3.4</version>
     </dependency>
     <dependency>
       <groupId>jakarta.xml.bind</groupId>


### PR DESCRIPTION
Increment the micro version of the projects so that the new grader jar can be used.

The consequences of having the grader jar's version defined in the top-level pom.xml.  I'm sure there is a better pattern for this.